### PR TITLE
Fix calls with variadic args - those would crash with --enable-maintainer-zts in php7

### DIFF
--- a/tests/runkit_function_variadic.phpt
+++ b/tests/runkit_function_variadic.phpt
@@ -1,0 +1,68 @@
+--TEST--
+runkit_function_redefine() function and runkit_function_remove(), with variadic functions
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+--INI--
+display_errors=on
+--FILE--
+<?php
+function create_function_mock($originalName, $temporaryName) {
+    if (!runkit_function_copy($originalName, $temporaryName))
+        throw new RuntimeException($originalName . ' runkit_method_copy create_function_mock');
+    if (!runkit_function_remove($originalName))
+        throw new RuntimeException($originalName . ' runkit_function_remove create_function_mock');
+    if (!runkit_function_add($originalName, '', 'printf("In mock: %s\n", serialize(func_get_args()));return null;'))
+        throw new RuntimeException($originalName . ' runkit_function_add create_function_mock');
+}
+
+function remove_function_mock($originalName, $temporaryName) {
+    if (!runkit_function_remove($originalName))
+        throw new RuntimeException($originalName . ' runkit_function_remove1 remove_function_mock');
+    if (!runkit_function_rename($temporaryName, $originalName))
+        throw new RuntimeException($originalName . ' runkit_function_rename remove_function_mock');
+}
+
+class FooImpl {
+    public function methodName($arg) {
+        return 33 + $arg;
+    }
+}
+
+function bar($method, ...$args) {
+    global $impl;
+    if ($impl === null) {
+        throw new RuntimeException('No $impl');
+    }
+
+    $id = getter();
+    return $id . call_user_func_array(array($impl, $method), $args);
+}
+
+function getter() {
+    return 'VALUE';
+}
+
+function main() {
+    ini_set('error_reporting', E_ALL | E_STRICT);
+    global $impl;
+    $impl = new FooImpl();
+    printf("Before mock: %s\n", var_export(bar('methodName', 0), true));
+    create_function_mock('bar', 'bar0000001123');
+    printf("After mock: %s\n", var_export(bar('methodName', 0), true));
+    remove_function_mock('bar', 'bar0000001123');
+    printf("After unmock: %s\n", var_export(bar('methodName', 100), true));
+    create_function_mock('bar', 'bar0000001123');
+    printf("After mock: %s\n", var_export(bar('methodName', 0), true));
+    remove_function_mock('bar', 'bar0000001123');
+    printf("After unmock: %s\n", var_export(bar('methodName', 100), true));
+}
+main();
+?>
+--EXPECT--
+Before mock: 'VALUE33'
+In mock: a:2:{i:0;s:10:"methodName";i:1;i:0;}
+After mock: NULL
+After unmock: 'VALUE133'
+In mock: a:2:{i:0;s:10:"methodName";i:1;i:0;}
+After mock: NULL
+After unmock: 'VALUE133'

--- a/tests/runkit_function_variadic_typed.phpt
+++ b/tests/runkit_function_variadic_typed.phpt
@@ -1,0 +1,68 @@
+--TEST--
+runkit_function_redefine() function, etc. can redefine variadic functions with return types.
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+--INI--
+display_errors=on
+--FILE--
+<?php
+function create_function_mock($originalName, $temporaryName) {
+    if (!runkit_function_copy($originalName, $temporaryName))
+        throw new RuntimeException($originalName . ' runkit_method_copy create_function_mock');
+    if (!runkit_function_remove($originalName))
+        throw new RuntimeException($originalName . ' runkit_function_remove create_function_mock');
+    if (!runkit_function_add($originalName, '', 'printf("In mock: %s\n", serialize(func_get_args()));return null;'))
+        throw new RuntimeException($originalName . ' runkit_function_add create_function_mock');
+}
+
+function remove_function_mock($originalName, $temporaryName) {
+    if (!runkit_function_remove($originalName))
+        throw new RuntimeException($originalName . ' runkit_function_remove1 remove_function_mock');
+    if (!runkit_function_rename($temporaryName, $originalName))
+        throw new RuntimeException($originalName . ' runkit_function_rename remove_function_mock');
+}
+
+class FooImpl {
+    public function methodName($arg) {
+        return 33 + $arg;
+    }
+}
+
+function bar($method, ...$args) : string {
+    global $impl;
+    if ($impl === null) {
+        throw new RuntimeException('No $impl');
+    }
+
+    $id = getter();
+    return $id . call_user_func_array(array($impl, $method), $args);
+}
+
+function getter() {
+    return 'VALUE';
+}
+
+function main() {
+    ini_set('error_reporting', E_ALL | E_STRICT);
+    global $impl;
+    $impl = new FooImpl();
+    printf("Before mock: %s\n", var_export(bar('methodName', 0), true));
+    create_function_mock('bar', 'bar0000001123');
+    printf("After mock: %s\n", var_export(bar('methodName', 0), true));
+    remove_function_mock('bar', 'bar0000001123');
+    printf("After unmock: %s\n", var_export(bar('methodName', 100), true));
+    create_function_mock('bar', 'bar0000001123');
+    printf("After mock: %s\n", var_export(bar('methodName', 0), true));
+    remove_function_mock('bar', 'bar0000001123');
+    printf("After unmock: %s\n", var_export(bar('methodName', 100), true));
+}
+main();
+?>
+--EXPECT--
+Before mock: 'VALUE33'
+In mock: a:2:{i:0;s:10:"methodName";i:1;i:0;}
+After mock: NULL
+After unmock: 'VALUE133'
+In mock: a:2:{i:0;s:10:"methodName";i:1;i:0;}
+After mock: NULL
+After unmock: 'VALUE133'

--- a/tests/runkit_method_variadic.phpt
+++ b/tests/runkit_method_variadic.phpt
@@ -1,0 +1,65 @@
+--TEST--
+runkit_method_redefine() function and runkit_method_remove(), with variadic functions
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+--INI--
+display_errors=on
+--FILE--
+<?php
+function create_mock($className, $originalName, $temporaryName) {
+    if (!runkit_method_copy($className, $temporaryName, $className, $originalName))
+        throw new RuntimeException($className . '::' . $originalName . ' runkit_method_copy create_mock');
+    if (!runkit_method_remove($className, $originalName))
+        throw new RuntimeException($className . '::' . $originalName . ' runkit_method_remove create_mock');
+    if (!runkit_method_add($className, $originalName, '', 'printf("In mock: %s\n", serialize(func_get_args()));return null;', RUNKIT_ACC_STATIC))
+        throw new RuntimeException($className . '::' . $originalName . ' runkit_method_add create_mock');
+}
+
+function remove_mock($className, $originalName, $temporaryName) {
+    if (!runkit_method_remove($className, $originalName))
+        throw new RuntimeException($className . '::' . $originalName . ' runkit_method_remove1 remove_mock');
+    if (!runkit_method_copy($className, $originalName, $className, $temporaryName))
+        throw new RuntimeException($className . '::' . $originalName . ' runkit_method_copy remove_mock');
+    if (!runkit_method_remove($className, $temporaryName))
+        throw new RuntimeException($className . '::' . $originalName . ' runkit_method_remove2 remove_mock');
+}
+
+class FooImpl {
+    public function methodName($arg) {
+        return 33 + $arg;
+    }
+}
+
+class foo {
+    public static function bar($method, ...$args) {
+        global $impl;
+        if ($impl === null) {
+            throw new RuntimeException('No $impl');
+        }
+
+        $id = self::getter();
+        return $id . call_user_func_array(array($impl, $method), $args);
+    }
+
+    public static function getter() {
+        return 'VALUE';
+    }
+}
+
+function main() {
+    ini_set('error_reporting', E_ALL | E_STRICT);
+    global $impl;
+    $impl = new FooImpl();
+    printf("Before mock: %s\n", var_export(foo::bar('methodName', 0), true));
+    create_mock('foo', 'bar', 'bar0000001123');
+    printf("After mock: %s\n", var_export(foo::bar('methodName', 0), true));
+    remove_mock('foo', 'bar', 'bar0000001123');
+    printf("After unmock: %s\n", var_export(foo::bar('methodName', 100), true));
+}
+main();
+?>
+--EXPECT--
+Before mock: 'VALUE33'
+In mock: a:2:{i:0;s:10:"methodName";i:1;i:0;}
+After mock: NULL
+After unmock: 'VALUE133'

--- a/tests/runkit_method_variadic_typed.phpt
+++ b/tests/runkit_method_variadic_typed.phpt
@@ -1,0 +1,66 @@
+--TEST--
+runkit_method_redefine() function and runkit_method_remove(), with variadic functions with return values
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+--INI--
+display_errors=on
+--FILE--
+<?php
+// This is the same as runkit_method_variadic.phpt, with return types added to the original redefined function
+function create_mock($className, $originalName, $temporaryName) {
+    if (!runkit_method_copy($className, $temporaryName, $className, $originalName))
+        throw new RuntimeException($className . '::' . $originalName . ' runkit_method_copy create_mock');
+    if (!runkit_method_remove($className, $originalName))
+        throw new RuntimeException($className . '::' . $originalName . ' runkit_method_remove create_mock');
+    if (!runkit_method_add($className, $originalName, '', 'printf("In mock: %s\n", serialize(func_get_args()));return null;', RUNKIT_ACC_STATIC))
+        throw new RuntimeException($className . '::' . $originalName . ' runkit_method_add create_mock');
+}
+
+function remove_mock($className, $originalName, $temporaryName) {
+    if (!runkit_method_remove($className, $originalName))
+        throw new RuntimeException($className . '::' . $originalName . ' runkit_method_remove1 remove_mock');
+    if (!runkit_method_copy($className, $originalName, $className, $temporaryName))
+        throw new RuntimeException($className . '::' . $originalName . ' runkit_method_copy remove_mock');
+    if (!runkit_method_remove($className, $temporaryName))
+        throw new RuntimeException($className . '::' . $originalName . ' runkit_method_remove2 remove_mock');
+}
+
+class FooImpl {
+    public function methodName($arg) {
+        return 33 + $arg;
+    }
+}
+
+class foo {
+    public static function bar($method, ...$args) : string {
+        global $impl;
+        if ($impl === null) {
+            throw new RuntimeException('No $impl');
+        }
+
+        $id = self::getter();
+        return $id . call_user_func_array(array($impl, $method), $args);
+    }
+
+    public static function getter() {
+        return 'VALUE';
+    }
+}
+
+function main() {
+    ini_set('error_reporting', E_ALL | E_STRICT);
+    global $impl;
+    $impl = new FooImpl();
+    printf("Before mock: %s\n", var_export(foo::bar('methodName', 0), true));
+    create_mock('foo', 'bar', 'bar0000001123');
+    printf("After mock: %s\n", var_export(foo::bar('methodName', 0), true));
+    remove_mock('foo', 'bar', 'bar0000001123');
+    printf("After unmock: %s\n", var_export(foo::bar('methodName', 100), true));
+}
+main();
+?>
+--EXPECT--
+Before mock: 'VALUE33'
+In mock: a:2:{i:0;s:10:"methodName";i:1;i:0;}
+After mock: NULL
+After unmock: 'VALUE133'


### PR DESCRIPTION
This bug has a chance of affecting php5 as well.
    
TODO: Test renaming methods with return types specified in php7 - those
are handled differently as op arrays.
